### PR TITLE
reuse route of the same pattern in NewRoute

### DIFF
--- a/router.go
+++ b/router.go
@@ -30,6 +30,12 @@ type NewRouteOpts struct {
 // current URL, then it returns the component, otherwise it returns
 // an EmptyComponent.
 func NewRoute(pattern string, c vecty.Component, opts NewRouteOpts) *Route {
+	for _, r := range routes {
+		if r.pattern == pattern {
+			return r
+		}
+	}
+
 	r := &Route{
 		pattern: pattern,
 		c:       c,


### PR DESCRIPTION
If a component which declares routes with router.NewRoute is rerendered, then the routes get duplicated in the internal slice `routes`.

This could happen if there are more than one vecty component using `NewRoute` in their `Render`, when the user is setting up a hierarchical routing paths.

It solves #6, maybe as well as #11.